### PR TITLE
Fix Deprecated AvCaptureDevice Enumeration

### DIFF
--- a/mac/platformcontext.mm
+++ b/mac/platformcontext.mm
@@ -90,7 +90,7 @@ bool PlatformContext::enumerateDevices()
     m_devices.clear();
     AVCaptureDeviceDiscoverySession *captureDeviceDiscoverySession = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInWideAngleCamera,AVCaptureDeviceTypeExternalUnknown]
                                           mediaType:AVMediaTypeVideo
-                                           position:AVCaptureDevicePositionBack];
+                                           position:AVCaptureDevicePositionUnspecified];
     for (AVCaptureDevice* device in [captureDeviceDiscoverySession devices])
     {
         platformDeviceInfo* deviceInfo = new platformDeviceInfo();

--- a/mac/platformcontext.mm
+++ b/mac/platformcontext.mm
@@ -88,7 +88,10 @@ bool PlatformContext::enumerateDevices()
     LOG(LOG_DEBUG, "enumerateDevices called\n");
 
     m_devices.clear();
-    for (AVCaptureDevice* device in [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo]) 
+    AVCaptureDeviceDiscoverySession *captureDeviceDiscoverySession = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInWideAngleCamera,AVCaptureDeviceTypeExternalUnknown]
+                                          mediaType:AVMediaTypeVideo
+                                           position:AVCaptureDevicePositionBack];
+    for (AVCaptureDevice* device in [captureDeviceDiscoverySession devices])
     {
         platformDeviceInfo* deviceInfo = new platformDeviceInfo();
         deviceInfo->m_captureDevice = CFBridgingRetain(device);
@@ -104,7 +107,7 @@ bool PlatformContext::enumerateDevices()
         NSRange vidRange = [device.modelID rangeOfString:@"VendorID_"];
         if (vidRange.length > 0)
         {
-            uint32_t maxLen = device.modelID.length - vidRange.location - 9;
+            unsigned long maxLen = device.modelID.length - vidRange.location - 9;
             maxLen = (maxLen > 5) ? 5 : maxLen;        
             deviceInfo->m_vid = [[device.modelID substringWithRange:NSMakeRange(vidRange.location + 9, maxLen)] intValue];
         }
@@ -117,7 +120,7 @@ bool PlatformContext::enumerateDevices()
         NSRange pidRange = [device.modelID rangeOfString:@"ProductID_"];
         if (pidRange.length > 0)
         {
-            uint32_t maxLen = device.modelID.length - pidRange.location - 10;
+            unsigned long maxLen = device.modelID.length - pidRange.location - 10;
             maxLen = (maxLen > 5) ? 5 : maxLen;
             deviceInfo->m_pid = [[device.modelID substringWithRange:NSMakeRange(pidRange.location + 10, maxLen)] intValue];
         }

--- a/mac/platformstream.mm
+++ b/mac/platformstream.mm
@@ -83,10 +83,10 @@
         if (CVPixelBufferLockBaseAddress(pixelBuffer, 0) == kCVReturnSuccess)
         {
             const uint8_t *pixelPtr = static_cast<const uint8_t*>(CVPixelBufferGetBaseAddress(pixelBuffer));
-            uint32_t frameBytes = CVPixelBufferGetHeight(pixelBuffer) *
+            unsigned long frameBytes = CVPixelBufferGetHeight(pixelBuffer) *
                   CVPixelBufferGetBytesPerRow(pixelBuffer);
 
-            m_stream->callback(pixelPtr, frameBytes);
+            m_stream->callback(pixelPtr, (uint32_t)frameBytes);
 
             CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
         }

--- a/mac/uvcctrl.mm
+++ b/mac/uvcctrl.mm
@@ -146,7 +146,7 @@ IOUSBDeviceInterface** UVCCtrl::findDevice(uint16_t vid, uint16_t pid, uint32_t 
     CFMutableDictionaryRef dict = IOServiceMatching(kIOUSBDeviceClassName);
 
     io_iterator_t serviceIterator;
-    IOServiceGetMatchingServices(kIOMasterPortDefault, dict, &serviceIterator);
+    IOServiceGetMatchingServices(NULL, dict, &serviceIterator);
 
     io_service_t device;
     while((device = IOIteratorNext(serviceIterator)) != 0)


### PR DESCRIPTION
This uses the method described [here](https://stackoverflow.com/questions/44735554/ios-deviceswithmediatype-deprecated) to replace the deprecated AvCaptureDevice enumeration on Mac. It queries for internal and external cameras. It also fixes some compiler deprecation warnings.